### PR TITLE
Update version of the Russian+English dictionary

### DIFF
--- a/Russian-English Bilingual.txt
+++ b/Russian-English Bilingual.txt
@@ -1,6 +1,6 @@
 English + Russian bilingual Hunspell dictionary.
 
 Home page: https://addons.mozilla.org/ru/firefox/addon/unified-russian-english-spell/
-Version: 1.0.1
+Version: 1.0.3.1webext
 Creator: Alexandr Petrenas
 License: GNU Lesser https://www.gnu.org/licenses/lgpl-3.0.html


### PR DESCRIPTION
Looks like the version of original Firefox addon has changed at least once (28 Nov 2018) since this dictionary was added to this repository, but the actual content of the dictionary is unmodified. Hence this commit contains the change in the version number only.